### PR TITLE
Matching contract

### DIFF
--- a/contracts/Matching.vy
+++ b/contracts/Matching.vy
@@ -1,0 +1,86 @@
+# @version 0.3.10
+"""
+@title YFI matching
+@author 1up
+@license GNU AGPLv3
+@notice
+    Matches locked YFI at a predefinied rate.
+    Anyone can transfer YFI into this contract.
+    Recipient can claim the matched amount as supYFI.
+    Owner can clawback any unmatched tokens.
+"""
+
+from vyper.interfaces import ERC20
+from vyper.interfaces import ERC4626
+
+interface LiquidLocker:
+    def token() -> address: view
+    def voting_escrow() -> address: view
+    def proxy() -> address: view
+    def deposit(_amount: uint256) -> uint256: nonpayable
+
+interface YearnVotingEscrow:
+    def locked(_account: address) -> uint256: view
+
+staking: public(immutable(ERC4626))
+liquid_locker: public(immutable(LiquidLocker))
+proxy: public(immutable(address))
+voting_escrow: public(immutable(YearnVotingEscrow))
+owner: public(immutable(address))
+recipient: public(immutable(address))
+matching_rate: public(immutable(uint256))
+matched: public(uint256)
+
+MATCHING_SCALE: constant(uint256) = 10_000
+
+@external
+def __init__(_staking: address, _owner: address, _recipient: address, _matching_rate: uint256):
+    """
+    @notice Constructor
+    @param _staking Staking contract address
+    @param _owner Matching contract owner
+    @param _recipient Matching recipient
+    @param _matching_rate Matching rate (bps)
+    """
+    staking = ERC4626(_staking)
+    liquid_locker = LiquidLocker(staking.asset())
+    proxy = liquid_locker.proxy()
+    voting_escrow = YearnVotingEscrow(liquid_locker.voting_escrow())
+    owner = _owner
+    recipient = _recipient
+    matching_rate = _matching_rate
+
+    assert ERC20(liquid_locker.token()).approve(liquid_locker.address, max_value(uint256), default_return_value=True)
+    assert ERC20(liquid_locker.address).approve(_staking, max_value(uint256), default_return_value=True)
+
+@external
+def match() -> (uint256, uint256):
+    """
+    @notice Matches any additional locked YFI since last call
+    @return Tuple with newly matched YFI amount, newly matched supYFI amount
+    @dev Can only be called by matching recipient
+    """
+    assert msg.sender == recipient
+    matched: uint256 = self.matched
+    # amount locked, excluding what is previously matched by this contract
+    locked: uint256 = voting_escrow.locked(proxy) - matched
+    # amount to newly match
+    match: uint256 = locked * matching_rate / MATCHING_SCALE - matched
+    assert match > 0
+    self.matched = matched + match
+
+    ll_match: uint256 = liquid_locker.deposit(match)
+    staking.deposit(ll_match, recipient)
+
+    return match, ll_match
+
+@external
+def revoke(_token: address, _amount: uint256):
+    """
+    @notice Send tokens back to the owner
+    @param _token Token address
+    @param _amount Amount of tokens to revoke
+    @dev Can only be called by owner
+    """
+    assert msg.sender == owner
+    assert ERC20(_token).transfer(owner, _amount, default_return_value=True)

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,0 +1,83 @@
+from ape import reverts
+from pytest import fixture
+from _constants import *
+
+SCALE = 69_420 * UNIT
+
+@fixture
+def staking_and_rewards(project, deployer, proxy, locking_token, discount_token, liquid_locker):
+    staking = project.Staking.deploy(liquid_locker, sender=deployer)
+    rewards = project.StakingRewards.deploy(proxy, staking, locking_token, discount_token, sender=deployer)
+    staking.set_rewards(rewards, sender=deployer)
+    return staking, rewards
+
+@fixture
+def staking(staking_and_rewards):
+    return staking_and_rewards[0]
+
+@fixture
+def rewards(staking_and_rewards):
+    return staking_and_rewards[1]
+
+@fixture
+def matching(project, ychad, deployer, alice, staking):
+    return project.Matching.deploy(staking, ychad, alice, 2_500, sender=deployer)
+
+def test_match(ychad, alice, locking_token, liquid_locker, staking, matching):
+    # locked yfi is matched at the specified rate
+    locking_token.transfer(matching, 3 * UNIT, sender=ychad)
+    locking_token.approve(liquid_locker, 8 * UNIT, sender=ychad)
+    liquid_locker.deposit(8 * UNIT, sender=ychad)
+    assert locking_token.balanceOf(matching) == 3 * UNIT
+    assert staking.balanceOf(alice) == 0
+    assert matching.matched() == 0
+    assert matching.match(sender=alice).return_value == (2 * UNIT, 2 * SCALE)
+    assert locking_token.balanceOf(matching) == UNIT
+    assert staking.balanceOf(alice) == 2 * SCALE
+    assert matching.matched() == 2 * UNIT
+
+def test_match_sequential(ychad, alice, locking_token, liquid_locker, matching):
+    # cant match more than once in a row without additional deposits
+    locking_token.transfer(matching, 3 * UNIT, sender=ychad)
+    locking_token.approve(liquid_locker, 8 * UNIT, sender=ychad)
+    liquid_locker.deposit(8 * UNIT, sender=ychad)
+    matching.match(sender=alice)
+    with reverts():
+        matching.match(sender=alice)
+
+def test_match_multiple(ychad, alice, locking_token, liquid_locker, staking, matching):
+    # matching multiple times only matches the difference
+    locking_token.transfer(matching, 10 * UNIT, sender=ychad)
+    locking_token.approve(liquid_locker, 12 * UNIT, sender=ychad)
+    liquid_locker.deposit(8 * UNIT, sender=ychad)
+    assert matching.match(sender=alice).return_value == (2 * UNIT, 2 * SCALE)
+    assert staking.balanceOf(alice) == 2 * SCALE
+    assert matching.matched() == 2 * UNIT
+    liquid_locker.deposit(4 * UNIT, sender=ychad)
+    assert matching.match(sender=alice).return_value == (UNIT, SCALE)
+    assert locking_token.balanceOf(matching) == 7 * UNIT
+    assert staking.balanceOf(alice) == 3 * SCALE
+    assert matching.matched() == 3 * UNIT
+
+def test_match_permission(ychad, bob, locking_token, liquid_locker, matching):
+    # only recipient can claim matched tokens
+    locking_token.transfer(matching, 3 * UNIT, sender=ychad)
+    locking_token.approve(liquid_locker, 8 * UNIT, sender=ychad)
+    liquid_locker.deposit(8 * UNIT, sender=ychad)
+    with reverts():
+        matching.match(sender=bob)
+
+def test_revoke(ychad, locking_token, matching):
+    # tokens can be revoked
+    locking_token.transfer(matching, 3 * UNIT, sender=ychad)
+    assert locking_token.balanceOf(matching) == 3 * UNIT
+    pre = locking_token.balanceOf(ychad)
+    matching.revoke(locking_token, UNIT, sender=ychad)
+    assert locking_token.balanceOf(matching) == 2 * UNIT
+    assert locking_token.balanceOf(ychad) == pre + UNIT
+
+def test_revoke_permission(ychad, alice, locking_token, matching):
+    # only owner can revoke tokens
+    locking_token.transfer(matching, 3 * UNIT, sender=ychad)
+    with reverts():
+        matching.revoke(locking_token, UNIT, sender=alice)


### PR DESCRIPTION
Matches locked YFI at a predefinied rate. Anyone can transfer YFI into this contract. Recipient can claim the matched amount as supYFI. Owner can clawback any unmatched tokens