### PR TITLE
Allow vest recipient to call through the vesting contract

### DIFF
--- a/contracts/vesting/VestingEscrowFactory.vy
+++ b/contracts/vesting/VestingEscrowFactory.vy
@@ -1,13 +1,15 @@
 # @version 0.3.10
 
 """
-@title Vesting Escrow Factory
+@title Liquid Locker Vesting Escrow Factory
 @author Curve Finance, Yearn Finance
 @license MIT
 @notice
     Stores YFI and distributes veYFI liquid locker tokens by deploying `VestingEscrowLL` contracts.
     The factory owner can approve liquid lockers for usage in vests, and approve specific
     operators to call functions through the vesting contract on its behalf.
+    Anyone can create a vest by depositing YFI. The vest recipient chooses which liquid locker 
+    to deposit their vest into.
 """
 
 from vyper.interfaces import ERC20

--- a/contracts/vesting/VestingEscrowLL.vy
+++ b/contracts/vesting/VestingEscrowLL.vy
@@ -41,6 +41,10 @@ event SetOperator:
     operator: indexed(address)
     flag: bool
 
+event Call:
+    operator: address
+    target: address
+
 factory: public(Factory)
 recipient: public(address)
 token: public(ERC20)
@@ -285,7 +289,12 @@ def call(_target: address, _data: Bytes[2048]):
     @notice Call another contract through the escrow contract
     @param _target Contract to call
     @param _data Calldata
-    @dev Can only be called by operators
+    @dev Can only be called by operators or vest recipient
     """
-    assert self.operators[msg.sender]
+    if msg.sender == self.recipient:
+        assert _target != self.token.address
+    else:
+        assert self.operators[msg.sender]
+
     raw_call(_target, _data, value=msg.value)
+    log Call(msg.sender, _target)


### PR DESCRIPTION
Recipient cannot call functions on the vesting contract directly