### PR TITLE
Only match what is available

### DIFF
--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -59,6 +59,20 @@ def test_match_multiple(ychad, alice, locking_token, liquid_locker, staking, mat
     assert staking.balanceOf(alice) == 3 * SCALE
     assert matching.matched() == 3 * UNIT
 
+def test_match_available(ychad, alice, locking_token, liquid_locker, staking, matching):
+    # can only match however many tokens are in the matching contract
+    locking_token.transfer(matching, 3 * UNIT, sender=ychad)
+    locking_token.approve(liquid_locker, 20 * UNIT, sender=ychad)
+    liquid_locker.deposit(8 * UNIT, sender=ychad)
+    assert matching.match(sender=alice).return_value == (2 * UNIT, 2 * SCALE)
+    assert staking.balanceOf(alice) == 2 * SCALE
+    assert matching.matched() == 2 * UNIT
+    liquid_locker.deposit(12 * UNIT, sender=ychad)
+    assert matching.match(sender=alice).return_value == (UNIT, SCALE)
+    assert locking_token.balanceOf(matching) == 0
+    assert staking.balanceOf(alice) == 3 * SCALE
+    assert matching.matched() == 3 * UNIT
+
 def test_match_permission(ychad, bob, locking_token, liquid_locker, matching):
     # only recipient can claim matched tokens
     locking_token.transfer(matching, 3 * UNIT, sender=ychad)

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -73,6 +73,21 @@ def test_match_available(ychad, alice, locking_token, liquid_locker, staking, ma
     assert staking.balanceOf(alice) == 3 * SCALE
     assert matching.matched() == 3 * UNIT
 
+def test_match_reup(ychad, alice, locking_token, liquid_locker, staking, matching):
+    # matching can continue after a second deposit
+    locking_token.transfer(matching, 3 * UNIT, sender=ychad)
+    locking_token.approve(liquid_locker, 20 * UNIT, sender=ychad)
+    liquid_locker.deposit(20 * UNIT, sender=ychad)
+    assert matching.match(sender=alice).return_value == (3 * UNIT, 3 * SCALE)
+    assert locking_token.balanceOf(matching) == 0
+    assert staking.balanceOf(alice) == 3 * SCALE
+    assert matching.matched() == 3 * UNIT
+    locking_token.transfer(matching, 10 * UNIT, sender=ychad)
+    assert matching.match(sender=alice).return_value == (2 * UNIT, 2 * SCALE)
+    assert locking_token.balanceOf(matching) == 8 * UNIT
+    assert staking.balanceOf(alice) == 5 * SCALE
+    assert matching.matched() == 5 * UNIT
+
 def test_match_permission(ychad, bob, locking_token, liquid_locker, matching):
     # only recipient can claim matched tokens
     locking_token.transfer(matching, 3 * UNIT, sender=ychad)


### PR DESCRIPTION
If the matching contract didnt have enough tokens to fully match, it would revert. This PR fixes this behaviour by capping the matching amount to the available balance.